### PR TITLE
feat(signal): add support for sending to individuals

### DIFF
--- a/backend/bec_atlas/ingestor/signal_manager.py
+++ b/backend/bec_atlas/ingestor/signal_manager.py
@@ -128,21 +128,62 @@ class SignalManager:
         if not isinstance(msg.scope, list):
             msg.scope = [msg.scope]
 
-        for scope in msg.scope:
-            group_id = self.get_group_id_for_deployment(deployment, scope)
-            if not group_id:
-                print(
-                    f"No Signal group found for deployment {deployment.deployment_id} and scope {scope}, cannot process message."
-                )
-                return
-            payload = {
-                "jsonrpc": "2.0",
-                "method": "send",
-                "params": {"message": self.get_text_from_message(msg), "groupId": group_id},
-            }
-            self.add_attachments_to_payload(msg, payload)
-            self.add_stickers_to_payload(msg, payload)
-            self.post(payload)
+        phone_numbers = [s for s in msg.scope if isinstance(s, str) and s.startswith("+")]
+        group_scopes = [s for s in msg.scope if isinstance(s, str) and not s.startswith("+")]
+        if phone_numbers:
+            self.send_message_to_individuals(msg, phone_numbers)
+
+        for scope in group_scopes:
+            self.send_message_to_group(msg, deployment, scope)
+
+    def send_message_to_individuals(
+        self, msg: messages.MessagingServiceMessage, phone_numbers: list[str]
+    ):
+        """
+        Send a message (including attachments and stickers) to individual phone numbers.
+
+        Args:
+            msg (messages.MessagingServiceMessage): The message containing the recipient phone numbers in the scope.
+            phone_numbers (list[str]): The list of phone numbers to send the message to.
+
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "send",
+            "params": {"message": self.get_text_from_message(msg), "recipients": phone_numbers},
+        }
+        self.add_attachments_to_payload(msg, payload)
+        self.add_stickers_to_payload(msg, payload)
+        self.post(payload)
+
+    def send_message_to_group(
+        self,
+        msg: messages.MessagingServiceMessage,
+        deployment: messages.DeploymentInfoMessage,
+        scope: str,
+    ):
+        """
+        Send a message to a Signal group associated with the deployment.
+
+        Args:
+            msg (messages.MessagingServiceMessage): The message to send.
+            deployment (messages.DeploymentInfoMessage): The deployment info message containing the session and messaging service info to determine the group id.
+            scope (str): The message scope.
+        """
+        group_id = self.get_group_id_for_deployment(deployment, scope)
+        if not group_id:
+            print(
+                f"No Signal group found for deployment {deployment.deployment_id} and scope {scope}, cannot process message."
+            )
+            return
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "send",
+            "params": {"message": self.get_text_from_message(msg), "groupId": group_id},
+        }
+        self.add_attachments_to_payload(msg, payload)
+        self.add_stickers_to_payload(msg, payload)
+        self.post(payload)
 
     def add_attachments_to_payload(self, msg: messages.MessagingServiceMessage, payload: dict):
         """
@@ -313,7 +354,7 @@ class SignalManager:
         pending_request = self.pending_signal_requests.get(source_number)
         if not pending_request:
             message = "Your signal group link has been received, but no pending signal link request was found. Please initiate the linking process first."
-            self.send_message_to_individuals(source_number, message)
+            self.send_simple_message_to_individuals(source_number, message)
             return False
         # We have a pending signal link request for this number, and the message contains a group link, so we proceed with the linking process.
         link = message.split()[0]
@@ -348,12 +389,12 @@ class SignalManager:
                 for banned_user in group.banned:
                     if banned_user.number == self.number:
                         message = "Your link request has been received, but BEC is currently banned from the group. Please add BEC back to the group."
-                        self.send_message_to_individuals(number, message)
+                        self.send_simple_message_to_individuals(number, message)
                         return
                 break
         if not group_id:
             message = "Your link request has been received, but no matching group was found on the Signal server. Please make sure to send a valid group link."
-            self.send_message_to_individuals(number, message)
+            self.send_simple_message_to_individuals(number, message)
             return
 
         patch_data = {"group_id": group_id, "group_link": link}
@@ -371,7 +412,9 @@ class SignalManager:
                 deployment_id = pending_request["deployment_id"]
             self.ingestor.broadcast_deployment_update(deployment_id)
 
-        self.send_message_to_individuals(number, "Your Signal group has been successfully linked.")
+        self.send_simple_message_to_individuals(
+            number, "Your Signal group has been successfully linked."
+        )
 
     def send_random_message(self, group_id: str, message_type: Literal["enter", "exit"]):
         """
@@ -442,9 +485,9 @@ class SignalManager:
             f"A request has been made to link the {link_scope} with a new group in Signal.\n\n"
             f"If you want to proceed with the linking, please reply to this message with a group link within the next 5 minutes."
         )
-        self.send_message_to_individuals(number, message)
+        self.send_simple_message_to_individuals(number, message)
 
-    def send_message_to_individuals(self, number: str | list[str], message: str):
+    def send_simple_message_to_individuals(self, number: str | list[str], message: str):
         """
         Send a message to an individual phone number or a list of phone numbers.
 

--- a/backend/tests/test_messaging_service_ingestor.py
+++ b/backend/tests/test_messaging_service_ingestor.py
@@ -79,9 +79,9 @@ def test_handle_message(ingestor):
     assert deployment_id in ingestor._deployment_info_cache
 
     # make sure that we've started a new subscription for the deployment info stream key
-    assert (
-        MessageEndpoints.atlas_deployment_info(deployment_name=deployment_id).endpoint
-        in ingestor.redis._stream_topics_subscription
+    assert ingestor.redis.any_stream_is_registered(
+        MessageEndpoints.atlas_deployment_info(deployment_name=deployment_id),
+        ingestor._handle_deployment_info_update,
     )
 
     assert ingestor.signal_manager.process.called_once_with(

--- a/backend/tests/test_signal_manager.py
+++ b/backend/tests/test_signal_manager.py
@@ -76,6 +76,51 @@ def test_process_posts_payload(signal_manager):
     assert payload["params"]["groupId"] == "test_group_id"
 
 
+def test_process_sends_direct_and_group_messages(signal_manager):
+    msg = messages.MessagingServiceMessage(
+        service_name="signal",
+        message=[messages.MessagingServiceTextContent(content="Hello, Signal!")],
+        scope=["+491234", "user1"],
+    )
+
+    deployment_info = messages.DeploymentInfoMessage(
+        deployment_id="test_deployment",
+        name="Test Deployment",
+        messaging_config=messages.MessagingConfig(
+            signal=messages.MessagingServiceScopeConfig(enabled=True, default=None),
+            scilog=messages.MessagingServiceScopeConfig(enabled=True, default=None),
+            teams=messages.MessagingServiceScopeConfig(enabled=False, default=None),
+        ),
+    )
+    with (
+        mock.patch.object(signal_manager, "send_message_to_individuals") as mock_send_direct,
+        mock.patch.object(signal_manager, "send_message_to_group") as mock_send_group,
+    ):
+        signal_manager.process(msg, deployment_info)
+
+    mock_send_direct.assert_called_once_with(msg, ["+491234"])
+    mock_send_group.assert_called_once_with(msg, deployment_info, "user1")
+
+
+def test_send_message_to_individuals_posts_recipients_payload(signal_manager):
+    msg = messages.MessagingServiceMessage(
+        service_name="signal",
+        message=[messages.MessagingServiceTextContent(content="Hello, Signal!")],
+        scope=["+491234"],
+    )
+
+    with mock.patch.object(signal_manager, "post") as mock_post:
+        signal_manager.send_message_to_individuals(msg, ["+491234", "+495678"])
+
+    mock_post.assert_called_once_with(
+        {
+            "jsonrpc": "2.0",
+            "method": "send",
+            "params": {"message": "Hello, Signal!", "recipients": ["+491234", "+495678"]},
+        }
+    )
+
+
 def test_handle_signal_link_request_stores_pending(signal_manager):
     msg_obj = MessageObject(
         value=messages.VariableMessage(
@@ -144,6 +189,30 @@ def test_check_pending_signal_link_request_ignores_non_link(signal_manager):
 
     assert result is False
     mock_complete.assert_not_called()
+
+
+def test_check_pending_signal_link_request_without_pending_sends_message(signal_manager):
+    event = {
+        "account": "+491234",
+        "envelope": {
+            "sourceNumber": "+491234",
+            "timestamp": 1,
+            "serverReceivedTimestamp": 1,
+            "serverDeliveredTimestamp": 1,
+            "dataMessage": {"timestamp": 1, "message": "https://signal.group/abcd some text"},
+        },
+    }
+
+    signal_event = SignalEventMessage(**event)
+
+    with mock.patch.object(signal_manager, "send_simple_message_to_individuals") as mock_send:
+        result = signal_manager.check_pending_signal_link_request(signal_event)
+
+    assert result is False
+    mock_send.assert_called_once_with(
+        "+491234",
+        "Your signal group link has been received, but no pending signal link request was found. Please initiate the linking process first.",
+    )
 
 
 def test_complete_signal_linking_calls_join_group(signal_manager):


### PR DESCRIPTION
Adding support for sending directly to individuals. I would have liked to have this available during recent debugging sessions. 